### PR TITLE
introduce usePerNixosConfigPackages option

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,4 +1,10 @@
-{ config, lib, self, inputs, ... }:
+{
+  config,
+  lib,
+  self,
+  inputs,
+  ...
+}:
 
 {
   options = {
@@ -21,12 +27,24 @@
             default = "x86_64-linux";
           };
 
+          usePerNixosConfigPackages = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Each system uses a version of nixpkgs with the already defined system in the nixosConfiguration.
+              As long this is enabled the colmena-flake.system has no effect. You can opt-out this feature
+              by setting this option to false.
+            '';
+          };
+
           sshConn = lib.mkOption {
             type = lib.types.attrsOf lib.types.str;
             description = ''
               The SSH connection string for colmena nodes
             '';
-            default = builtins.mapAttrs (_: v: "${v.targetUser}@${v.targetHost}") config.colmena-flake.deployment;
+            default = builtins.mapAttrs (
+              _: v: "${v.targetUser}@${v.targetHost}"
+            ) config.colmena-flake.deployment;
             readOnly = true;
           };
         };
@@ -39,23 +57,34 @@
       inherit (config.colmena-flake) sshConn;
     };
 
-    colmena = {
-      meta = {
-        nixpkgs = import inputs.nixpkgs {
-          inherit (config.colmena-flake) system;
-          overlays = [ ];
-        };
-        # https://github.com/zhaofengli/colmena/issues/60#issuecomment-1510496861
-        nodeSpecialArgs = builtins.mapAttrs (_: value: value._module.specialArgs) self.nixosConfigurations;
-      };
-    } // builtins.mapAttrs
-      (name: value: {
-        imports = value._module.args.modules ++ [{
-          deployment = config.colmena-flake.deployment.${name};
-        }];
-      })
-      (lib.filterAttrs
-        (k: _: lib.hasAttr k config.colmena-flake.deployment)
-        self.nixosConfigurations);
+    colmena =
+      {
+        meta =
+          {
+            nixpkgs = import inputs.nixpkgs {
+              inherit (config.colmena-flake) system;
+              overlays = [ ];
+            };
+            # https://github.com/zhaofengli/colmena/issues/60#issuecomment-1510496861
+            nodeSpecialArgs = builtins.mapAttrs (_: value: value._module.specialArgs) self.nixosConfigurations;
+
+          }
+          // lib.optionalAttrs config.colmena-flake.usePerNixosConfigPackages {
+            nodeNixpkgs = builtins.mapAttrs (
+              _: value:
+              import inputs.nixpkgs {
+                inherit (value.config.nixpkgs) system;
+                overlays = [ ];
+              }
+            ) self.nixosConfigurations;
+          };
+      }
+      // builtins.mapAttrs (name: value: {
+        imports = value._module.args.modules ++ [
+          {
+            deployment = config.colmena-flake.deployment.${name};
+          }
+        ];
+      }) (lib.filterAttrs (k: _: lib.hasAttr k config.colmena-flake.deployment) self.nixosConfigurations);
   };
 }


### PR DESCRIPTION
Fix deployment issues on mixed system architectures.

Observed deployment problems when running colmena having mixed system architectures (`aarch64-linux` and `x86_64-linux`). Adjusted the setup to work for my environment. Feel free to adopt or close as needed.
